### PR TITLE
Cosmetic changes for running Magnum on mutinode

### DIFF
--- a/ansible/deploy-openstack-config.yml
+++ b/ansible/deploy-openstack-config.yml
@@ -93,6 +93,13 @@
         dest: "{{ src_directory }}/{{ kayobe_config_name }}/etc/kayobe/environments/{{ kayobe_config_environment }}/inventory/hosts"
         mode: "0644"
 
+    - name: Ensure hosts are added to /etc/hosts
+      become: true
+      ansible.builtin.lineinfile:
+        path: "/etc/hosts"
+        line: "{{ item.value}}\t{{item.key}}"
+      loop: "{{ (lookup('file', 'files/admin-oc-networks.yml') | from_yaml).admin_oc_ips | dict2items }}"
+
     - name: Ensure VXLAN VNI has been set
       ansible.builtin.lineinfile:
         path: "{{ src_directory }}/{{ kayobe_config_name }}/etc/kayobe/environments/{{ kayobe_config_environment }}/inventory/group_vars/all/vxlan.yml"

--- a/ansible/deploy-openstack-config.yml
+++ b/ansible/deploy-openstack-config.yml
@@ -97,7 +97,7 @@
       become: true
       ansible.builtin.lineinfile:
         path: "/etc/hosts"
-        line: "{{ item.value}}\t{{item.key}}"
+        line: "{{ item.value }}\t{{ item.key}}"
       loop: "{{ (lookup('file', 'files/admin-oc-networks.yml') | from_yaml).admin_oc_ips | dict2items }}"
 
     - name: Ensure VXLAN VNI has been set

--- a/ansible/deploy-openstack-config.yml
+++ b/ansible/deploy-openstack-config.yml
@@ -97,7 +97,7 @@
       become: true
       ansible.builtin.lineinfile:
         path: "/etc/hosts"
-        line: "{{ item.value }}\t{{ item.key}}"
+        line: "{{ item.value }}\t{{ item.key }}"
       loop: "{{ (lookup('file', 'files/admin-oc-networks.yml') | from_yaml).admin_oc_ips | dict2items }}"
 
     - name: Ensure VXLAN VNI has been set

--- a/volumes.tf
+++ b/volumes.tf
@@ -1,7 +1,7 @@
 resource "openstack_blockstorage_volume_v3" "volumes" {
   count = var.storage_count
   name  = format("%s-osd-%02d", var.prefix, count.index + 1)
-  size  = 20
+  size  = 40
 }
 
 resource "openstack_compute_volume_attach_v2" "attachments" {


### PR DESCRIPTION
Added overcloud nodes to ansible control hosts /etc/hosts for convenience sake.
Added more storage to ceph nodes, for magnum.