### PR TITLE
Re add homedir ownership fix

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -187,12 +187,14 @@ Review the vars defined within `ansible/vars/defaults.yml`. In here you can cust
 However, make sure to define `ssh_key_path` to point to the location of the SSH key in use amongst the nodes and also `vxlan_vni` which should be unique value between 1 to 100,000.
 VNI should be much smaller than the officially supported limit of 16,777,215 as we encounter errors when attempting to bring interfaces up that use a high VNI. You must set``vault_password_path``; this should be set to the path to a file containing the Ansible vault password.
 
-Finally run the ansible playbooks. 
-You may need to run `grow-control-host.yml` if you are using LVM images and the LVMs are too small to install Ansible.
+Finally run the ansible playbooks.
+You may need to run `fix-homedir-ownership.yml` if you are using an image that has `ansible_user` not owning their own home folder.
+You may also need to run `grow-control-host.yml` if you are using LVM images and the LVMs are too small to install Ansible.
 If not you can skip that playbook and proceed onto `deploy-openstack-config` which shall configure your Ansible control host in preparation for deployment.
 
 .. code-block:: console
 
+   ansible-playbook -i $(terraform output -raw ansible_control_access_ip_v4), ansible/fix-homedir-ownership.yml -e ansible_user=cloud-user
    ansible-playbook -i $(terraform output -raw ansible_control_access_ip_v4), ansible/grow-control-host.yml -e ansible_user=cloud-user
    ansible-playbook -i $(terraform output -raw ansible_control_access_ip_v4), ansible/deploy-openstack-config.yml -e ansible_user=cloud-user
 

--- a/ansible/fix-homedir-ownership.yml
+++ b/ansible/fix-homedir-ownership.yml
@@ -1,0 +1,32 @@
+---
+- name: Fix Home Directory Ownership
+  hosts: all
+  gather_facts: true
+  vars_files:
+    - files/admin-oc-networks.yml
+  vars:
+    # At the time of running this playbook the home directory is not owned by the user.
+    # Therefore, we will not be permitted to store the Ansible temporary directory in the home folder.
+    # This must be relocated to some where that can be written to by the remote user.
+    ansible_remote_tmp: "/tmp/ansible"
+  tasks:
+    - name: Ensure hosts are reachable
+      ansible.builtin.command:
+        cmd: "ping -c 1 -w 2 {{ item.value }}"
+      loop:
+        "{{ (lookup('file', 'files/admin-oc-networks.yml') | from_yaml).admin_oc_ips | dict2items }}"
+      changed_when: false
+      register: ping_results
+      retries: 15
+      delay: 3
+      until: ping_results is succeeded
+
+    - name: Ensure homedir of ansible control node is owned by cloud-user # noqa: no-changed-when
+      ansible.builtin.command:
+        cmd: "sudo chown -R cloud-user: ."
+
+    - name: Ensure homedir of all nodes is owned by cloud-user # noqa: no-changed-when
+      ansible.builtin.command:
+        cmd: "ssh -oStrictHostKeyChecking=no cloud-user@{{ item.value }} sudo chown -R cloud-user: ."
+      loop: "{{ (lookup('file', 'files/admin-oc-networks.yml') | from_yaml).admin_oc_ips | dict2items }}"
+      delegate_to: localhost


### PR DESCRIPTION
The homedir ownership bug (the home directory of the given ansible user is owned by root, not the user) has returned. This change brings back the fix that was previously removed when the issue was resolved in the past.