### PR TITLE
Fix bug in ensuring hosts are reachable

### DIFF
--- a/ansible/deploy-openstack-config.yml
+++ b/ansible/deploy-openstack-config.yml
@@ -25,7 +25,7 @@
 
     - name: Ensure hosts are reachable
       ansible.builtin.command:
-        cmd: "ping -c 1 -w 2 {{ item.key }}"
+        cmd: "ping -c 1 -w 2 {{ item.value }}"
       loop: "{{ (lookup('file', 'files/admin-oc-networks.yml') | from_yaml).admin_oc_ips | dict2items }}"
       changed_when: false
       register: ping_results


### PR DESCRIPTION
Fixes a bug that uses the key from admin_oc_ips instead of the value. This causes an issue as they key is the hostname which has not yet been added to /etc/hosts.