### PR TITLE
Refactor host configuration playbooks into one

### DIFF
--- a/ansible/configure-hosts.yml
+++ b/ansible/configure-hosts.yml
@@ -1,0 +1,9 @@
+---
+- import_playbook: fix-homedir-ownership.yml
+  tags: fix-homedir
+- import_playbook: add-fqdn.yml
+  tags: fqdn
+- import_playbook: grow-control-host.yml
+  tags: lvm
+- import_playbook: deploy-openstack-config.yml
+  tags: deploy


### PR DESCRIPTION
The list of host configuration playbooks was slowly growing.

This change introduces one master playbook which imports the others, reducing complexity.