### PR TITLE
fix: uuidgen is provided by `uuid-runtime`

### DIFF
--- a/templates/deploy-openstack.tpl
+++ b/templates/deploy-openstack.tpl
@@ -42,10 +42,10 @@ set +x
 export KAYOBE_VAULT_PASSWORD=$(cat ~/vault.password)
 set -x
 
-# Install uuidgen on ubuntu
+# Install uuid-runtime on ubuntu
 if $(which apt 2>/dev/null >/dev/null); then
     sudo apt update
-    sudo apt -y install uuidgen
+    sudo apt -y install uuid-runtime
 fi
 
 # Configure hosts


### PR DESCRIPTION
`uuidgen` is provided by `uuid-runtime` this change makes sure to download the correct package.

It appears that uuid-runtime is found within both [Debian and Ubuntu](https://pkgs.org/search/?q=uuid-runtime) and that [Centos includes it as a part of util-linux](https://www.unix.com/man-page/centos/1/uuidgen/).
