### PR TITLE
TLS fixes

### DIFF
--- a/templates/deploy-openstack.tpl
+++ b/templates/deploy-openstack.tpl
@@ -90,11 +90,11 @@ cat $KAYOBE_CONFIG_PATH/environments/$KAYOBE_ENVIRONMENT/kolla/globals-tls-confi
 
 # Create vault configuration for barbican
 ansible-vault decrypt --vault-password-file ~/vault.password $KAYOBE_CONFIG_PATH/environments/$KAYOBE_ENVIRONMENT/secrets.yml
-sed -i "s/secret_id:.*/secret_id: $(uuidgen)/g" KAYOBE_CONFIG_PATH/environments/$KAYOBE_ENVIRONMENT/secrets.yml
+sed -i "s/secret_id:.*/secret_id: $(uuidgen)/g" $KAYOBE_CONFIG_PATH/environments/$KAYOBE_ENVIRONMENT/secrets.yml
 ansible-vault encrypt --vault-password-file ~/vault.password $KAYOBE_CONFIG_PATH/environments/$KAYOBE_ENVIRONMENT/secrets.yml
 kayobe playbook run $KAYOBE_CONFIG_PATH/ansible/vault-deploy-barbican.yml
 ansible-vault decrypt --vault-password-file ~/vault.password $KAYOBE_CONFIG_PATH/environments/$KAYOBE_ENVIRONMENT/secrets.yml
-sed -i "s/role_id:.*/role_id: $(cat /tmp/barbican-role-id)/g" KAYOBE_CONFIG_PATH/environments/$KAYOBE_ENVIRONMENT/secrets.yml
+sed -i "s/role_id:.*/role_id: $(cat /tmp/barbican-role-id)/g" $KAYOBE_CONFIG_PATH/environments/$KAYOBE_ENVIRONMENT/secrets.yml
 ansible-vault encrypt --vault-password-file ~/vault.password $KAYOBE_CONFIG_PATH/environments/$KAYOBE_ENVIRONMENT/secrets.yml
 rm /tmp/barbican-role-id
 

--- a/templates/deploy-openstack.tpl
+++ b/templates/deploy-openstack.tpl
@@ -64,9 +64,6 @@ pip install -r $${config_directories[kayobe]}/requirements.txt
 
 # Deploy hashicorp vault to the seed
 kayobe playbook run $KAYOBE_CONFIG_PATH/ansible/vault-deploy-seed.yml
-ansible-vault encrypt --vault-password-file ~/vault.password $KAYOBE_CONFIG_PATH/environments/$KAYOBE_ENVIRONMENT/vault/OS-TLS-INT.pem
-ansible-vault encrypt --vault-password-file ~/vault.password $KAYOBE_CONFIG_PATH/environments/$KAYOBE_ENVIRONMENT/vault/seed-vault-keys.json
-ansible-vault encrypt --vault-password-file ~/vault.password $KAYOBE_CONFIG_PATH/environments/$KAYOBE_ENVIRONMENT/vault/overcloud.key
 
 kayobe overcloud service deploy -kt haproxy
 

--- a/templates/deploy-openstack.tpl
+++ b/templates/deploy-openstack.tpl
@@ -64,6 +64,9 @@ pip install -r $${config_directories[kayobe]}/requirements.txt
 
 # Deploy hashicorp vault to the seed
 kayobe playbook run $KAYOBE_CONFIG_PATH/ansible/vault-deploy-seed.yml
+ansible-vault encrypt --vault-password-file ~/vault.password $KAYOBE_CONFIG_PATH/environments/$KAYOBE_ENVIRONMENT/vault/OS-TLS-INT.pem
+ansible-vault encrypt --vault-password-file ~/vault.password $KAYOBE_CONFIG_PATH/environments/$KAYOBE_ENVIRONMENT/vault/seed-vault-keys.json
+ansible-vault encrypt --vault-password-file ~/vault.password $KAYOBE_CONFIG_PATH/environments/$KAYOBE_ENVIRONMENT/vault/*.key
 
 kayobe overcloud service deploy -kt haproxy
 


### PR DESCRIPTION
The `$` special character is missing in two places when attempting to modify the config mid deployment.

Also with the inclusion of FQDN the `overcloud.key` is actual named `internal.infra.mos.{{ root_domain }}`. Unfortunately the Terraform is not aware of the `root_domain` as this id defined within the Ansible variables. Rather than transfer this variable over to Terraform I think the better and more immediate solution would be to not encrypt the key. Whilst not something you would do in production it is of little consequence in a test environment that will be thrown away a few hours later.
 