### PR TITLE
Update deployment script for Zed+

### DIFF
--- a/templates/deploy-openstack.tpl
+++ b/templates/deploy-openstack.tpl
@@ -121,10 +121,17 @@ set -x
 git -C $${config_directories[kayobe]} submodule init
 git -C $${config_directories[kayobe]} submodule update
 
+# Set base image for kayobe container. Use rocky 9 for zed+ CentOS otherwise
+if grep -Eq "(2023|zed)" $${config_directories[kayobe]}/.gitreview; then
+    export BASE_IMAGE=rockylinux:9
+else
+    export BASE_IMAGE=quay.io/centos/centos:stream8
+fi
+
 if [[ "$(sudo docker image ls)" == *"kayobe"* ]]; then
   echo "Image already exists skipping docker build"
 else
-  sudo DOCKER_BUILDKIT=1 docker build --network host --file $${config_directories[kayobe]}/.automation/docker/kayobe/Dockerfile --tag kayobe:latest $${config_directories[kayobe]}
+  sudo DOCKER_BUILDKIT=1 docker build --network host --build-arg BASE_IMAGE=$$BASE_IMAGE --file $${config_directories[kayobe]}/.automation/docker/kayobe/Dockerfile --tag kayobe:latest $${config_directories[kayobe]}
 fi
 
 set +x


### PR DESCRIPTION
Allows zed/antelope deployments to run tempest without user intervention