### PR TITLE
Default controllers and computes for VMs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -115,8 +115,8 @@ Generate Terraform variables:
    multinode_vm_subnet  = "stackhpc-ipv4-vlan-subnet-v2"
    compute_count    = "2"
    controller_count = "3"
-   compute_disk_size = 0
-   controller_disk_size = 0
+   compute_disk_size = 100
+   controller_disk_size = 100
 
    ssh_public_key = "~/.ssh/changeme.pub"
    ssh_user       = "changeme"


### PR DESCRIPTION
We currently don't have the capacity to run multinodes on baremetals. Change the README to add volumes to the controllers and computes by default, so that VM multinodes work out the box.