### PR TITLE
Add growroot playbook for overcloud-* images

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -109,7 +109,7 @@ Generate Terraform variables:
    seed_disk_size = 100
 
    multinode_flavor     = "changeme"
-   multinode_image      = "CentOS-stream8-lvm"
+   multinode_image      = "changeme"
    multinode_keypair    = "changeme"
    multinode_vm_network = "stackhpc-ipv4-vlan-v2"
    multinode_vm_subnet  = "stackhpc-ipv4-vlan-subnet-v2"
@@ -131,9 +131,11 @@ Generate Terraform variables:
 
    EOF
 
-You will need to set the `multinode_flavor`, `multinode_keypair`, `prefix`,
-`ssh_public_key`, and `ssh_user` (such as using the user `ubuntu`
-if you're using ubuntu or `cloud-user` on Rocky Linux 9, etc).
+You will need to set the `multinode_flavor`, `multinode_image`,
+`multinode_keypair`, `prefix`, `ssh_public_key`, and `ssh_user` (such as using
+the user `ubuntu` if you're using ubuntu or `cloud-user` on Rocky Linux 9,
+etc). `overcloud-*` OS images are recommended, as they are most often used in
+production.
 
 The `multinode_flavor` will change the flavor used for controller and compute
 nodes. Both virtual machines and baremetal are supported, but the 
@@ -206,6 +208,7 @@ Finally, run the configure-hosts playbook.
 This playbook sequentially executes 4 other playbooks:
 
 #. ``fix-homedir-ownership.yml`` - Ensures the ``ansible_user`` owns their home directory. Tag: ``fix-homedir``
+#. ``growroot.yml`` - Grows the root PV of the Ansible control host. Tag: ``growroot``
 #. ``add-fqdn.yml`` - Ensures FQDNs are added to ``/etc/hosts``. Tag: ``fqdn``
 #. ``grow-control-host.yml`` - Applies LVM configuration to the control host to ensure it has enough space to continue with the rest of the deployment. Tag: ``lvm`` 
 #. ``deploy-openstack-config.yml`` - Deploys the OpenStack configuration to the control host. Tag: ``deploy``

--- a/ansible/configure-hosts.yml
+++ b/ansible/configure-hosts.yml
@@ -1,6 +1,8 @@
 ---
 - import_playbook: fix-homedir-ownership.yml
   tags: fix-homedir
+- import_playbook: growroot.yml
+  tags: growroot
 - import_playbook: add-fqdn.yml
   tags: fqdn
 - import_playbook: grow-control-host.yml

--- a/ansible/growroot.yml
+++ b/ansible/growroot.yml
@@ -1,0 +1,73 @@
+---
+- name: Grow root PV
+  hosts: ansible_control
+  vars_files:
+    - vars/defaults.yml 
+  # Avoid using facts because this may be used as a pre overcloud host
+  # configure hook, and we don't want to populate the fact cache (if one is in
+  # use) with the bootstrap user's context.
+  gather_facts: false
+  vars:
+    growroot_vg: "rootvg"
+    # Don't assume facts are present.
+    os_family: "{{ ansible_facts.os_family | default('RedHat') }}"
+    # Ignore LVM check
+    growroot_ignore_lvm_check: false
+
+  tasks:
+    - name: Check LVM status
+      shell:
+        cmd: vgdisplay | grep -q lvm2
+      changed_when: false
+      failed_when: false
+      check_mode: false
+      register: lvm_check
+      become: true
+
+    - block:
+        - name: Check if growpart is installed
+          shell:
+            cmd: type growpart
+          changed_when: false
+          failed_when: false
+          check_mode: false
+          register: growpart_check
+          become: true
+
+        - name: Get root PV device
+          command: "pvs --select vg_name={{ growroot_vg }} --reportformat json"
+          register: pvs
+          become: true
+          changed_when: false
+          check_mode: false
+
+        - name: Fail if root PV device not found
+          fail:
+            msg: >
+              Expected LVM physical volume devices not found in volume group {{ growroot_vg }}
+          when: (pvs.stdout | from_json).report[0].pv | length == 0
+
+        - name: Grow partition
+          command: "growpart {{ disk }} {{ part_num }}"
+          vars:
+            pv: "{{ pvs.stdout | from_json }}"
+            disk_tmp: "{{ pv.report[0].pv[0].pv_name[:-1] }}"
+            disk: "{{ disk_tmp[:-1] if disk_tmp[-1] == 'p' else disk_tmp }}"
+            part_num: "{{ pv.report[0].pv[0].pv_name[-1] }}"
+          become: true
+          failed_when: "growpart.rc != 0 and 'NOCHANGE' not in growpart.stdout"
+          changed_when: "'NOCHANGE' not in growpart.stdout"
+          register: growpart
+
+        - name: Grow LVM PV
+          command: "pvresize {{ disk }}"
+          vars:
+            pv: "{{ pvs.stdout | from_json }}"
+            disk: "{{ pv.report[0].pv[0].pv_name }}"
+          become: true
+      when: lvm_check.rc == 0 or growroot_ignore_lvm_check
+#      when: "'NOCHANGE' not in growpart.stdout"
+# Commenting out the conditional because growpart is already triggered by cloud-init - hence it emits NOCHANGE
+# Cloud-Inits growpart implementation has a bug https://bugzilla.redhat.com/show_bug.cgi?id=2122575
+# PVresize is not being triggered
+


### PR DESCRIPTION
`overcloud-*` images require the growroot playbook to be run early on. This change integrates the playbook into the standard deployment and edits the README to now recommend `overcloud-*` images