### PR TITLE
Fix templating for docker build in deploy template

### DIFF
--- a/templates/deploy-openstack.tpl
+++ b/templates/deploy-openstack.tpl
@@ -131,7 +131,7 @@ fi
 if [[ "$(sudo docker image ls)" == *"kayobe"* ]]; then
   echo "Image already exists skipping docker build"
 else
-  sudo DOCKER_BUILDKIT=1 docker build --network host --build-arg BASE_IMAGE=$$BASE_IMAGE --file $${config_directories[kayobe]}/.automation/docker/kayobe/Dockerfile --tag kayobe:latest $${config_directories[kayobe]}
+  sudo DOCKER_BUILDKIT=1 docker build --network host --build-arg BASE_IMAGE=$BASE_IMAGE --file $${config_directories[kayobe]}/.automation/docker/kayobe/Dockerfile --tag kayobe:latest $${config_directories[kayobe]}
 fi
 
 set +x


### PR DESCRIPTION
I'm amazed this hasn't come up before but the templating is wrong for the docker image build so it currently fails. It seems that  `$` only needs to be escaped when it's at the start of a 'word'