### PR TITLE
Install kayobe-config requirements.txt

### DIFF
--- a/ansible/deploy-openstack-config.yml
+++ b/ansible/deploy-openstack-config.yml
@@ -155,9 +155,15 @@
         virtualenv_command: "/usr/bin/python3 -m venv"
         state: latest
 
-    - name: Ensure `kayobe` is present
+    - name: Fix up `kayobe-config` requirements to point to local checkout
+      ansible.builtin.replace:
+        path: "{{ src_directory }}/{{ kayobe_config_name }}/requirements.txt"
+        regexp: "^kayobe@.*$"
+        replace: "kayobe@git+file://{{ src_directory }}/{{ kayobe_name }}"
+
+    - name: Ensure `kayobe-config` requirements are installed
       ansible.builtin.pip:
-        name: "{{ src_directory }}/{{ kayobe_name }}/"
+        requirements: "{{ src_directory }}/{{ kayobe_config_name }}/requirements.txt"
         virtualenv: "{{ ansible_env.HOME }}/venvs/kayobe"
         virtualenv_command: "/usr/bin/python3 -m venv"
         state: present


### PR DESCRIPTION
CIS benchmark hardening, and HashiCorp Vault playbooks require additional python dependencies.