### PR TITLE
Fix issue with runs being incorrectly flagged as failed

### DIFF
--- a/ansible/deploy-openstack.yml
+++ b/ansible/deploy-openstack.yml
@@ -83,4 +83,4 @@
           To see results:
 
           {{ connection_info }}
-      when: rc_slurp.content | b64decode != "0"
+      when: rc_slurp.content | b64decode | trim != "0"


### PR DESCRIPTION
Newline characters were causing this check to erroneously fail.