### PR TITLE
Fix issue building kayobe image

### DIFF
--- a/ansible/deploy-openstack-config.yml
+++ b/ansible/deploy-openstack-config.yml
@@ -128,13 +128,6 @@
         create: true
       loop: "{{ kayobe_config_custom }}"
 
-    - name: Ensure Kayobe repository is present
-      ansible.builtin.git:
-        repo: "{{ kayobe_repo }}"
-        version: "{{ kayobe_version }}"
-        dest: "{{ src_directory }}/{{ kayobe_name }}"
-        update: false
-
     - name: Ensure `venvs` directory exists
       ansible.builtin.file:
         path: "{{ ansible_env.HOME }}/venvs"
@@ -159,7 +152,7 @@
       ansible.builtin.replace:
         path: "{{ src_directory }}/{{ kayobe_config_name }}/requirements.txt"
         regexp: "^kayobe@.*$"
-        replace: "kayobe@git+file://{{ src_directory }}/{{ kayobe_name }}"
+        replace: "kayobe@git+{{ kayobe_repo }}@{{ kayobe_version }}"
 
     - name: Ensure `kayobe-config` requirements are installed
       ansible.builtin.pip:

--- a/ansible/vars/defaults.yml
+++ b/ansible/vars/defaults.yml
@@ -17,9 +17,8 @@ kayobe_config_environment: ci-multinode
 #       timezone: Europe/London
 kayobe_config_custom: []
 
-kayobe_repo: https://github.com/stackhpc/kayobe.git
+kayobe_repo: https://github.com/stackhpc/kayobe
 kayobe_version: stackhpc/2023.1
-kayobe_name: kayobe
 
 openstack_config_repo: https://github.com/stackhpc/openstack-config-multinode
 openstack_config_version: main


### PR DESCRIPTION
A regression was introduced in:

https://github.com/stackhpc/terraform-kayobe-multinode/pull/55

which meant that the Kayobe docker image failed to build. This is because requirements.txt was updated to point a local path that did not exist inside the docker image during the build. I've changed the logic to update the requirements.txt to use the ansible variables that configure the kayobe checkout.