### PR TITLE
Wait for cloud-init to finish running apt update

### DIFF
--- a/ansible/configure-hosts.yml
+++ b/ansible/configure-hosts.yml
@@ -1,4 +1,6 @@
 ---
+- import_playbook: wait-control-host.yml
+  tags: wait
 - import_playbook: grow-control-host.yml
   tags: lvm
 - import_playbook: deploy-openstack-config.yml

--- a/ansible/grow-control-host.yml
+++ b/ansible/grow-control-host.yml
@@ -1,16 +1,10 @@
 ---
 - name: Grow Control Host
   hosts: ansible_control
-  gather_facts: false
+  gather_facts: true
   vars_files:
     - vars/defaults.yml
   tasks:
-    - name: Ensure hosts are reachable
-      ansible.builtin.wait_for_connection:
-
-    - name: Gather facts
-      setup:
-
     - name: Check LVM status
       shell:
         cmd: vgdisplay | grep -q lvm2

--- a/ansible/wait-control-host.yml
+++ b/ansible/wait-control-host.yml
@@ -1,0 +1,21 @@
+---
+- name: Wait for Control Host to be reachable
+  hosts: ansible_control
+  gather_facts: false
+  vars_files:
+    - vars/defaults.yml
+  tasks:
+    - name: Ensure hosts are reachable
+      ansible.builtin.wait_for_connection:
+
+    # The cloud-final.service unit can run apt update, which acquires the dpkg
+    # lock and prevents other tasks from acquiring it. Wait for it to finish.
+    - name: Wait for cloud init to finish
+      community.general.cloud_init_data_facts:
+        filter: status
+      register: cloud_init_result
+      until:
+        - cloud_init_result.cloud_init_data_facts.status.v1.stage is defined
+        - not cloud_init_result.cloud_init_data_facts.status.v1.stage
+      retries: 72
+      delay: 5


### PR DESCRIPTION
The cloud-final.service unit can run apt update, which acquires the dpkg
lock and prevents other tasks from acquiring it. Wait for it to finish.
