### PR TITLE
Add a default for growroot_ignore_lvm_check

### DIFF
--- a/ansible/grow-control-host.yml
+++ b/ansible/grow-control-host.yml
@@ -2,6 +2,8 @@
 - name: Grow Control Host
   hosts: ansible_control
   gather_facts: true
+  vars:
+    growroot_ignore_lvm_check: false
   vars_files:
     - vars/defaults.yml
   tasks:


### PR DESCRIPTION
Without this the grow-control-host.yml playbook may fail when LVM is not in use.