### PR TITLE
Use bash for Ansible shell module Ubuntu when using source

### DIFF
--- a/ansible/deploy-openstack-config.yml
+++ b/ansible/deploy-openstack-config.yml
@@ -292,6 +292,7 @@
           source {{ src_directory }}/{{ kayobe_config_name }}/kayobe-env --environment {{ kayobe_config_environment }}
           export KAYOBE_VAULT_PASSWORD="$(cat ~/vault.password)"
           kayobe control host {% if upgrade | bool %}upgrade{% else %}bootstrap{% endif %}
+        executable: /bin/bash
 
     - name: Ensure OpenStack Config repository is present
       ansible.builtin.git:

--- a/ansible/fetch-logs.yml
+++ b/ansible/fetch-logs.yml
@@ -34,6 +34,7 @@
           else
             echo "Missing diagnostics playbook - skipping"
           fi
+        executable: /bin/bash
       failed_when: false
       register: diagnostics_result
 


### PR DESCRIPTION
The default sh shell in Ubuntu does not support the source command.
