### PR TITLE
Install required packages on Ansible control host

### DIFF
--- a/ansible/deploy-openstack-config.yml
+++ b/ansible/deploy-openstack-config.yml
@@ -57,9 +57,12 @@
         fail_msg: "FIPS policy does not currently support ed25519 SSH keys on RHEL family systems"
       when: ansible_facts['os_family'] == "RedHat"
 
-    - name: Ensure git is present
+    - name: Ensure required packages are present
       ansible.builtin.package:
-        name: git
+        name:
+          - git
+          - tmux
+          - vim
         state: present
       become: true
 


### PR DESCRIPTION
These should be installed by cloud-init based on
templates/userdata.cfg.tpl, but we have recently seen cases where they
were not installed on Ubuntu during nightly runs. Perhaps a failure in
cloud-init?
