### PR TITLE
Use bash for all shell tasks

### DIFF
--- a/ansible/deploy-openstack-config.yml
+++ b/ansible/deploy-openstack-config.yml
@@ -85,6 +85,7 @@
           if [[ -f {{ kayobe_environment_path }}/kolla/globals-tls-config.yml ]]; then
             sed -i 's/^kolla_enable_tls_internal: true/# kolla_enable_tls_internal: true/g' {{ kayobe_environment_path }}/kolla.yml
           fi
+        executable: /bin/bash
       when: upgrade | bool
       vars:
         kayobe_environment_path: "{{ src_directory }}/kayobe-config/etc/kayobe/environments/{{ kayobe_config_environment }}"
@@ -133,6 +134,7 @@
           if [[ -f {{ kayobe_environment_path }}/kolla/globals-tls-config.yml ]]; then
             sed -i 's/# kolla_enable_tls_internal: true/kolla_enable_tls_internal: true/g' {{ kayobe_environment_path }}/kolla.yml
           fi
+        executable: /bin/bash
       when: upgrade | bool
       vars:
         kayobe_environment_path: "{{ src_directory }}/kayobe-config/etc/kayobe/environments/{{ kayobe_config_environment }}"
@@ -217,6 +219,7 @@
         cmd: >
           awk -F'=' '/defaultbranch/ {print $2}' {{ src_directory }}/{{ kayobe_config_name }}/.gitreview |
           sed -E "s,(stable|unmaintained)/,,"
+        executable: /bin/bash
       register: openstack_release
       changed_when: false
 

--- a/ansible/grow-control-host.yml
+++ b/ansible/grow-control-host.yml
@@ -10,6 +10,7 @@
     - name: Check LVM status
       shell:
         cmd: vgdisplay | grep -q lvm2
+        executable: /bin/bash
       changed_when: false
       failed_when: false
       check_mode: false
@@ -20,6 +21,7 @@
         - name: Check if growpart is installed
           shell:
             cmd: type growpart
+            executable: /bin/bash
           changed_when: false
           failed_when: false
           check_mode: false


### PR DESCRIPTION
Without this we see the following issue during Ubuntu upgrades:

  '/bin/sh: 1: [[: not found'

In the 'Revert TLS changes to avoid git conflicts (upgrade)' task in
deploy-openstack-config.yml.
