### PR TITLE
Support RabbitMQ minor version upgrades and Quorum migration

### DIFF
--- a/ansible/deploy-openstack-config.yml
+++ b/ansible/deploy-openstack-config.yml
@@ -86,6 +86,18 @@
       vars:
         kayobe_environment_path: "{{ src_directory }}/kayobe-config/etc/kayobe/environments/{{ kayobe_config_environment }}"
 
+    - name: Revert RabbitMQ changes to avoid git conflicts (upgrade)
+      ansible.builtin.shell:
+        cmd: >-
+          if grep "om_enable_rabbitmq_high_availability: false" {{ kayobe_environment_path }}/kolla/globals.yml ; then
+            sed -i -e 's/om_enable_rabbitmq_high_availability: false/om_enable_rabbitmq_high_availability: true/' \
+              -e 's/om_enable_rabbitmq_quorum_queues: true/om_enable_rabbitmq_quorum_queues: false/' \
+              {{ kayobe_environment_path }}/kolla/globals.yml
+          fi
+      when: upgrade | bool
+      vars:
+        kayobe_environment_path: "{{ src_directory }}/kayobe-config/etc/kayobe/environments/{{ kayobe_config_environment }}"
+
     - name: Stash Kayobe Config changes (upgrade)
       ansible.builtin.command:
         cmd: git stash

--- a/ansible/files/multinode.sh
+++ b/ansible/files/multinode.sh
@@ -337,6 +337,14 @@ function upgrade_overcloud() {
 }
 
 function rabbit_migration() {
+  # Ensure RabbitMQ is upgraded to 3.13
+  if kayobe overcloud host command run -l controllers -b --command "docker exec rabbitmq rabbitmqctl --version | grep 3.11" --show-output; then
+    kayobe kolla ansible run "rabbitmq-upgrade 3.12"
+  fi
+  if kayobe overcloud host command run -l controllers -b --command "docker exec rabbitmq rabbitmqctl --version | grep 3.12" --show-output; then
+    kayobe kolla ansible run "rabbitmq-upgrade 3.13"
+  fi
+
   # Set quorum flag and execute RabbitMQ queue migration script.
   if [[ -f $KAYOBE_CONFIG_PATH/../../tools/rabbitmq-quorum-migration.sh ]]; then
     sed -i -e 's/om_enable_rabbitmq_high_availability: true/om_enable_rabbitmq_high_availability: false/' \

--- a/ansible/files/multinode.sh
+++ b/ansible/files/multinode.sh
@@ -336,6 +336,19 @@ function upgrade_overcloud() {
   kayobe overcloud service upgrade
 }
 
+function rabbit_migration() {
+  # Set quorum flag and execute RabbitMQ queue migration script.
+  if [[ -f $KAYOBE_CONFIG_PATH/../../tools/rabbitmq-quorum-migration.sh ]]; then
+    sed -i -e 's/om_enable_rabbitmq_high_availability: true/om_enable_rabbitmq_high_availability: false/' \
+        -e 's/om_enable_rabbitmq_quorum_queues: false/om_enable_rabbitmq_quorum_queues: true/' \
+        $KAYOBE_CONFIG_PATH/environments/$KAYOBE_ENVIRONMENT/kolla/globals.yml
+    $KAYOBE_CONFIG_PATH/../../tools/rabbitmq-quorum-migration.sh
+  else
+    echo "Migration script not found. Check Openstack Release"
+    return 1
+  fi
+}
+
 function usage() {
   set +x
 
@@ -351,6 +364,7 @@ function usage() {
   echo "  build_kayobe_image"
   echo "  run_tempest"
   echo "  upgrade_overcloud"
+  echo "  rabbit_migration"
 }
 
 function main() {
@@ -373,7 +387,7 @@ function main() {
       $cmd
       ;;
     # Standard commands.
-    (build_kayobe_image|deploy_full|deploy_seed|deploy_overcloud|deploy_wazuh|create_resources|run_tempest|upgrade_overcloud)
+    (build_kayobe_image|deploy_full|deploy_seed|deploy_overcloud|deploy_wazuh|create_resources|run_tempest|upgrade_overcloud|rabbit_migration)
       setup
       $cmd
       report_success


### PR DESCRIPTION
Adds a new command - `rabbit_migration` to execute a RabbitMQ minor version upgrade and Quorum queue migration. Required for Antelope->Caracal upgrades