### PR TITLE
Replace KAYOBE_CONFIG_ROOT with KAYOBE_CONFIG_PATH

### DIFF
--- a/ansible/files/multinode.sh
+++ b/ansible/files/multinode.sh
@@ -371,7 +371,7 @@ function upgrade_overcloud() {
 function upgrade_prerequisites() {
   # Run the upgrade prerequisites script if it exists.
   workaround_ansible_rc13_bug
-  [[ ! -f $KAYOBE_CONFIG_ROOT/tools/upgrade-prerequisites.sh ]] || $KAYOBE_CONFIG_ROOT/tools/upgrade-prerequisites.sh
+  [[ ! -f $KAYOBE_CONFIG_PATH/../../tools/upgrade-prerequisites.sh ]] || $KAYOBE_CONFIG_PATH/../../tools/upgrade-prerequisites.sh
 }
 
 function usage() {


### PR DESCRIPTION
KAYOBE_CONFIG_ROOT is not guaranteed to work.

See https://github.com/stackhpc/stackhpc-kayobe-config/pull/1335