### PR TITLE
Added configurable tags global to compute instances

### DIFF
--- a/compute_instances.tf
+++ b/compute_instances.tf
@@ -47,6 +47,7 @@ resource "openstack_compute_instance_v2" "ansible_control" {
       user_data
     ]
   }
+  tags = var.compute_tags
 }
 
 resource "openstack_compute_instance_v2" "seed" {
@@ -74,6 +75,7 @@ resource "openstack_compute_instance_v2" "seed" {
   timeouts {
     create = "90m"
   }
+  tags = var.compute_tags
 }
 
 resource "openstack_compute_instance_v2" "compute" {
@@ -102,6 +104,7 @@ resource "openstack_compute_instance_v2" "compute" {
   timeouts {
     create = "90m"
   }
+  tags = var.compute_tags
 }
 resource "openstack_compute_instance_v2" "controller" {
   name         = format("%s-controller-%02d", var.prefix, count.index + 1)
@@ -129,6 +132,8 @@ resource "openstack_compute_instance_v2" "controller" {
   timeouts {
     create = "90m"
   }
+
+  tags = var.compute_tags
 }
 
 resource "openstack_compute_instance_v2" "storage" {
@@ -157,6 +162,7 @@ resource "openstack_compute_instance_v2" "storage" {
   timeouts {
     create = "90m"
   }
+  tags = var.compute_tags
 }
 
 resource "openstack_compute_instance_v2" "wazuh_manager" {
@@ -182,4 +188,5 @@ resource "openstack_compute_instance_v2" "wazuh_manager" {
   timeouts {
     create = "90m"
   }
+  tags = var.compute_tags
 }

--- a/compute_instances.tf
+++ b/compute_instances.tf
@@ -47,7 +47,7 @@ resource "openstack_compute_instance_v2" "ansible_control" {
       user_data
     ]
   }
-  tags = var.compute_tags
+  tags = var.instance_tags
 }
 
 resource "openstack_compute_instance_v2" "seed" {
@@ -75,7 +75,7 @@ resource "openstack_compute_instance_v2" "seed" {
   timeouts {
     create = "90m"
   }
-  tags = var.compute_tags
+  tags = var.instance_tags
 }
 
 resource "openstack_compute_instance_v2" "compute" {
@@ -104,7 +104,7 @@ resource "openstack_compute_instance_v2" "compute" {
   timeouts {
     create = "90m"
   }
-  tags = var.compute_tags
+  tags = var.instance_tags
 }
 resource "openstack_compute_instance_v2" "controller" {
   name         = format("%s-controller-%02d", var.prefix, count.index + 1)
@@ -133,7 +133,7 @@ resource "openstack_compute_instance_v2" "controller" {
     create = "90m"
   }
 
-  tags = var.compute_tags
+  tags = var.instance_tags
 }
 
 resource "openstack_compute_instance_v2" "storage" {
@@ -162,7 +162,7 @@ resource "openstack_compute_instance_v2" "storage" {
   timeouts {
     create = "90m"
   }
-  tags = var.compute_tags
+  tags = var.instance_tags
 }
 
 resource "openstack_compute_instance_v2" "wazuh_manager" {
@@ -188,5 +188,5 @@ resource "openstack_compute_instance_v2" "wazuh_manager" {
   timeouts {
     create = "90m"
   }
-  tags = var.compute_tags
+  tags = var.instance_tags
 }

--- a/variables.tf
+++ b/variables.tf
@@ -135,3 +135,9 @@ variable "volume_type" {
   type = string
   default = ""
 }
+
+variable "compute_tags" {
+  description = "Set of tags to be applied to all compute instances"
+  type = list(string)
+  default = []
+}

--- a/variables.tf
+++ b/variables.tf
@@ -136,8 +136,8 @@ variable "volume_type" {
   default = ""
 }
 
-variable "compute_tags" {
-  description = "Set of tags to be applied to all compute instances"
+variable "instance_tags" {
+  description = "Set of tags to be applied to all instances"
   type = list(string)
   default = []
 }


### PR DESCRIPTION
Allows compute instances to be marked for cleanup by https://github.com/stackhpc/stackhpc-openstack-gh-workflows/pull/11 and https://github.com/stackhpc/stackhpc-kayobe-config/pull/1295