### PR TITLE
Add IdentitiesOnly to ssh config in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -212,6 +212,7 @@ If the deployed instances are behind an SSH bastion you must ensure that your SS
       IdentityFile ~/.ssh/key
       UserKnownHostsFile /dev/null
       StrictHostKeyChecking no
+      IdentitiesOnly yes
 
 Configure Terraform variables
 =============================


### PR DESCRIPTION
This is useful when you use yubikeys, as otherwise the ssh-agent will offer your secure key on each Ansible task.