### PR TITLE
multinode.sh: detect controller containers unhealthy before tempest

### DIFF
--- a/ansible/files/multinode.sh
+++ b/ansible/files/multinode.sh
@@ -376,7 +376,9 @@ function run_tempest() {
 
 function run_tests() {
   rc=0
-  if ! run_tempest; then
+  if ! kayobe overcloud host command run -l controllers --command "! docker ps 2>&1| grep unhealthy"; then
+    rc=1
+  elif ! run_tempest; then
     rc=1
   fi
   return $rc

--- a/ansible/files/multinode.sh
+++ b/ansible/files/multinode.sh
@@ -454,6 +454,7 @@ function usage() {
   echo "  create_resources"
   echo "  build_kayobe_image"
   echo "  run_tempest"
+  echo "  run_tests (includes run_tempest)"
   echo "  upgrade_overcloud"
   echo "  upgrade_prerequisites"
   echo "  minor_upgrade"
@@ -479,7 +480,7 @@ function main() {
       $cmd
       ;;
     # Standard commands.
-    (build_kayobe_image|deploy_full|deploy_seed|deploy_overcloud|deploy_wazuh|create_resources|run_tempest|upgrade_overcloud|upgrade_prerequisites|minor_upgrade)
+    (build_kayobe_image|deploy_full|deploy_seed|deploy_overcloud|deploy_wazuh|create_resources|run_tempest|run_tests|upgrade_overcloud|upgrade_prerequisites|minor_upgrade)
       setup
       $cmd
       report_success


### PR DESCRIPTION
This adds a basic check that all controller container are healthy to the multinode test.

The check is done before tempest is run.