### PR TITLE
Update deprecated result_format option in ansible.cfg

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,5 +1,5 @@
 [defaults]
-stdout_callback = yaml
+callback_result_format = yaml
 callbacks_enabled = timer, profile_tasks, profile_roles
 host_key_checking = False
 pipelining = True


### PR DESCRIPTION
Backport of #103