### PR TITLE
feat: add support for `RGW`

### DIFF
--- a/templates/hosts.tpl
+++ b/templates/hosts.tpl
@@ -36,6 +36,9 @@ ${ element }
 %{ endfor ~}
 
 [rgws]
+%{ for element in storage_hostname ~}
+${ element }
+%{ endfor ~}
 
 [monitoring:children]
 controllers


### PR DESCRIPTION
In order for `RGW` to be deployed the RGW group needs to include the storage hosts as locations for `RGW` daemons to be deployed.