### PR TITLE
Limit ansible to version 13 to avoid breaking change in ansible-core 2.21

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -229,7 +229,7 @@ You must ensure that you have `Ansible installed <https://docs.ansible.com/ansib
 
 .. code-block:: console
 
-   pip install --user ansible
+   pip install --user -r ansible/requirements.txt
 
 Install the Ansible galaxy requirements.
 

--- a/ansible/requirements.txt
+++ b/ansible/requirements.txt
@@ -1,0 +1,2 @@
+# ansible 14 / ansible-core 2.21 breaks inventory plugins with 'required' removed from get_bin_path()
+ansible>13,<14


### PR DESCRIPTION
Here is the error in multinode workflows:

  [WARNING]: Failed to parse inventory with 'auto' plugin: get_bin_path() got an unexpected keyword argument 'required'

  Failed to parse inventory with 'auto' plugin.

  <<< caused by >>>

  get_bin_path() got an unexpected keyword argument 'required'
  Origin: <inventory plugin 'auto' with source '/home/runner/_work/stackhpc-kayobe-config/stackhpc-kayobe-config/terraform-kayobe-multinode/ansible/inventory.yml'>