### PR TITLE
Backport 102 Move from Terraform to OpenTofu to 2024.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@
 # Crash log files
 crash.log
 
-# Ignore any .tfvars files that are generated automatically for each Terraform run. Most
+# Ignore any .tfvars files that are generated automatically for each OpenTofu run. Most
 # .tfvars files are managed as part of configuration and so should be included in
 # version control.
 #
@@ -25,5 +25,5 @@ override.tf.json
 #
 # !example_override.tf
 
-# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# Include tfplan files to ignore the plan output of command: tofu plan -out=tfplan
 # example: *tfplan*

--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -1,7 +1,7 @@
-# This file is maintained automatically by "terraform init".
+# This file is maintained automatically by "tofu init".
 # Manual edits may be lost in future updates.
 
-provider "registry.terraform.io/ansible/ansible" {
+provider "registry.opentofu.org/ansible/ansible" {
   version     = "1.3.0"
   constraints = "1.3.0"
   hashes = [
@@ -21,36 +21,31 @@ provider "registry.terraform.io/ansible/ansible" {
     "zh:c73c81d669b5be4f6cc900277a42b14b73dc96ebd7bbc518ccd7984c26761c65",
     "zh:e9e76b2d86a96f90168b06e411281cae5b2b01b260cd6211b9d67923e8414072",
     "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
-    "zh:f63ed6016d237e177f5a7d2a6a485ef7094a97b44944cbdf9428b30b0c7c76b8",
   ]
 }
 
-provider "registry.terraform.io/hashicorp/local" {
+provider "registry.opentofu.org/hashicorp/local" {
   version = "2.4.0"
   hashes = [
-    "h1:R97FTYETo88sT2VHfMgkPU3lzCsZLunPftjSI5vfKe8=",
-    "h1:ZUEYUmm2t4vxwzxy1BvN1wL6SDWrDxfH7pxtzX8c6d0=",
-    "zh:53604cd29cb92538668fe09565c739358dc53ca56f9f11312b9d7de81e48fab9",
-    "zh:66a46e9c508716a1c98efbf793092f03d50049fa4a83cd6b2251e9a06aca2acf",
-    "zh:70a6f6a852dd83768d0778ce9817d81d4b3f073fab8fa570bff92dcb0824f732",
-    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
-    "zh:82a803f2f484c8b766e2e9c32343e9c89b91997b9f8d2697f9f3837f62926b35",
-    "zh:9708a4e40d6cc4b8afd1352e5186e6e1502f6ae599867c120967aebe9d90ed04",
-    "zh:973f65ce0d67c585f4ec250c1e634c9b22d9c4288b484ee2a871d7fa1e317406",
-    "zh:c8fa0f98f9316e4cfef082aa9b785ba16e36ff754d6aba8b456dab9500e671c6",
-    "zh:cfa5342a5f5188b20db246c73ac823918c189468e1382cb3c48a9c0c08fc5bf7",
-    "zh:e0e2b477c7e899c63b06b38cd8684a893d834d6d0b5e9b033cedc06dd7ffe9e2",
-    "zh:f62d7d05ea1ee566f732505200ab38d94315a4add27947a60afa29860822d3fc",
-    "zh:fa7ce69dde358e172bd719014ad637634bbdabc49363104f4fca759b4b73f2ce",
+    "h1:pWJMQ+uRtVtHg97vU2zSCuYcZTuDQ7FJz+QanfSGMXM=",
+    "zh:184d6ec1f0e77713b37f0d9cf943b1371f2aa2f44c2c5a618978e897ce3dccab",
+    "zh:2205a7955a4051c2c25e69646a60746d9416b73001491808ae5d10620f7b7ac1",
+    "zh:256ddc56457f725819dc6be62f2d0bb3b9fee40a61771317bb32353df5b5c1a0",
+    "zh:70146e603f540523f6fa2251dd52c225db5a92bda8c07fd198ed51ae2b50176b",
+    "zh:8c3f9fe12ab8843e25ff7edabc26e01df4a0e8db204e432600a4c77a95ec0535",
+    "zh:b003e421f643d14247d31dcb7f0f6470c46f772d0e15a175a555a525ce344bf2",
+    "zh:b4c8ad7c5696aeb2a52adf6047d1e01943fafa57dc123d5192542527406ffd72",
+    "zh:c3b6fbfa431f3c085621c74596ee63681a278fd433a4758f33c627e8936d5cb3",
+    "zh:d2e57b19295b326d84ca5f39b797849d901170d5509aa7558f2a6545c9ce72a9",
+    "zh:e2307421b0b380eb0e8fcee008e0af98ae30fccbfc9e9a1d24d952489e9b0df9",
   ]
 }
 
-provider "registry.terraform.io/terraform-provider-openstack/openstack" {
+provider "registry.opentofu.org/terraform-provider-openstack/openstack" {
   version     = "1.49.0"
   constraints = "1.49.0"
   hashes = [
     "h1:6I8IFY2JDKc6ntkF3C5w1rgIATpbdmvgWrnV7kcRq5o=",
-    "h1:OW5PF9z5+VWzDmOUY2lefQBmU7+Ytb6XdbrcEBUvjRQ=",
     "zh:18b0a5d528fe3eb30060cf478db5a5efaed9d9837f4afb35ba58f0196ba6a51c",
     "zh:3cd7f28730ed216740a7bc62169a0d630f95ecdaee1162952aab67011fcf8831",
     "zh:60a827813523fd77e75d0145cd066cb4c2a89453083a5bd9e0712a8423bdc14a",

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 Terraform Kayobe Multinode
 ==========================
 
-This Terraform configuration deploys a requested amount of instances on an OpenStack cloud, to be
+This OpenTofu configuration deploys a requested amount of instances on an OpenStack cloud, to be
 used as a Multinode Kayobe test environment. This includes:
 
 * 1x Ansible control host
@@ -15,8 +15,8 @@ used as a Multinode Kayobe test environment. This includes:
 The high-level workflow to deploy a cluster is as follows:
 
 * Prerequisites
-* Configure Terraform and Ansible
-* Deploy infrastructure on OpenStack using Terraform
+* Configure Terraform/OpenTofu and Ansible
+* Deploy infrastructure on OpenStack using Terraform/OpenTofu
 * Configure Ansible control host using Ansible
 * Deploy multi-node OpenStack using Kayobe
 
@@ -36,10 +36,10 @@ Scripts
 * ``scripts/deploy.sh`` - end-to-end cluster deployment and testing.
 * ``scripts/tear-down.sh`` - tear down test cluster infrastructure.
 
-Terraform
+OpenTofu
 ---------
 
-Terraform configuration deploys test cluster infrastructure on an OpenStack
+OpenTofu configuration deploys test cluster infrastructure on an OpenStack
 cloud. It provides outputs that can be used to populate Kayobe Configuration
 with the details of the test infrastructure.
 
@@ -86,45 +86,61 @@ arguments.
 Prerequisites
 =============
 
-These instructions show how to use this Terraform configuration manually. They
-assume you are running an Ubuntu host that will be used to run Terraform. The
-machine should have access to the API of the OpenStack cloud that will host the
-infrastructure, and network access to the Ansible control host once it has been
-deployed. This may be achieved by direct SSH access, a floating IP on the
-Ansible control host, or using an SSH bastion.
+These instructions show how to use this OpenTofu configuration manually. They
+assume you are running an Ubuntu or Fedora host that will be used to run
+OpenTofu. The machine should have access to the API of the OpenStack cloud that
+will host the infrastructure, and network access to the Ansible control host
+once it has been deployed. This may be achieved by direct SSH access, a floating
+IP on the Ansible control host, or using an SSH bastion.
 
 The OpenStack cloud should have sufficient capacity to deploy the
 infrastructure, and a suitable image registered in Glance. Ideally the image
 should be one of the overcloud host images defined in StackHPC Kayobe
 configuration and available in `Ark <https://ark.stackhpc.com>`__.
 
-Install Terraform:
+Install OpenTofu on Ubuntu Noble:
 
 .. code-block:: console
 
-   wget -qO - terraform.gpg https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /usr/share/keyrings/terraform-archive-keyring.gpg
-   sudo echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/terraform-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/terraform.list
+   sudo apt-get update
+   sudo apt-get install -y apt-transport-https ca-certificates curl gnupg
+   sudo install -m 0755 -d /usr/share/keyrings
+   curl -fsSL https://get.opentofu.org/opentofu.gpg | sudo tee /usr/share/keyrings/opentofu.gpg >/dev/null
+   curl -fsSL https://packages.opentofu.org/opentofu/tofu/gpgkey | sudo gpg --no-tty --batch --dearmor -o /usr/share/keyrings/opentofu-repo.gpg >/dev/null
+   sudo chmod a+r /usr/share/keyrings/opentofu.gpg /usr/share/keyrings/opentofu-repo.gpg
+   printf '%s\n%s' "deb [signed-by=/usr/share/keyrings/opentofu.gpg,/usr/share/keyrings/opentofu-repo.gpg] https://packages.opentofu.org/opentofu/tofu/any/ any main" \
+   "deb-src [signed-by=/usr/share/keyrings/opentofu.gpg,/usr/share/keyrings/opentofu-repo.gpg] https://packages.opentofu.org/opentofu/tofu/any/ any main" \
+    | sudo tee /etc/apt/sources.list.d/opentofu.list >/dev/null
+   sudo chmod a+r /etc/apt/sources.list.d/opentofu.list
    sudo apt update
-   sudo apt install git terraform
+   sudo apt install git tofu
 
-Clone and initialise this Terraform config repository:
+Install OpenTofu on Fedora 43
+
+.. code-block:: console
+
+   dnf check-update
+   sudo dnf install git opentofu
+
+
+Clone and initialise this OpenTofu config repository:
 
 .. code-block:: console
 
    git clone https://github.com/stackhpc/terraform-kayobe-multinode
    cd terraform-kayobe-multinode
 
-Initialise Terraform:
+Initialise OpenTofu:
 
 .. code-block:: console
 
-   terraform init
+   tofu init
 
 Generate an SSH keypair. Note that `ED25519 keys are not currently supported by RHEL
 <https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html-single/securing_networks/index#making-openssh-more-secure_assembly_using-secure-communications-between-two-systems-with-openssh>`__
 when using the FIPS security standard (as enabled by the CIS benchmark hardening
 scripts in kayobe-config). The public key will be registered in OpenStack as a
-keypair and authorised by the instances deployed by Terraform. The private and
+keypair and authorised by the instances deployed by OpenTofu. The private and
 public keys will be transferred to the Ansible control host to allow it to
 connect to the other hosts. Note that password-protected keys are not currently
 supported.
@@ -157,32 +173,57 @@ Export environment variables to use the correct cloud and provide a password (yo
    export OS_CLOUD=openstack
    export OS_CLOUD_CONFIG_FILE=<path>/<to>/clouds.yml
 
-Or you can source the provided `init.sh` script which shall initialise terraform and export two variables.
-`OS_CLOUD` is a variable which is used by Terraform and must match an entry within `clouds.yml` (Not needed if you have sourced the openrc file).
+Or you can source the provided `init.sh` script which shall initialise OpenTofu and export two variables.
+`OS_CLOUD` is a variable which is used by OpenTofu and must match an entry within `clouds.yml` (Not needed if you have sourced the openrc file).
 `OS_PASSWORD` is the password used to authenticate when signing into OpenStack.
 
 .. code-block:: console
    source ./init.sh
 
-   Initializing the backend...
+	Initializing the backend...
 
-   Initializing provider plugins...
-   - Reusing previous version of terraform-provider-openstack/openstack from the dependency lock file
-   - Reusing previous version of hashicorp/local from the dependency lock file
-   - Using previously-installed terraform-provider-openstack/openstack v1.48.0
-   - Using previously-installed hashicorp/local v2.2.3
+	Successfully configured the backend "local"! OpenTofu will automatically
+	use this backend unless the backend configuration changes.
 
-   Terraform has been successfully initialized!
+	Initializing provider plugins...
+	- Finding terraform-provider-openstack/openstack versions matching "1.49.0"...
+	- Finding ansible/ansible versions matching "1.3.0"...
+	- Reusing previous version of hashicorp/local from the dependency lock file
+	- Installing hashicorp/local v2.4.0...
+	- Installed hashicorp/local v2.4.0 (signed, key ID 0C0AF313E5FD9F80)
+	- Installing terraform-provider-openstack/openstack v1.49.0...
+	- Installed terraform-provider-openstack/openstack v1.49.0 (signed, key ID 4F80527A391BEFD2)
+	- Installing ansible/ansible v1.3.0...
+	- Installed ansible/ansible v1.3.0. Signature validation was skipped due to the registry not containing GPG keys for this provider
 
-   You may now begin working with Terraform. Try running "terraform plan" to see
-   any changes that are required for your infrastructure. All Terraform commands
-   should now work.
+	Providers are signed by their developers.
+	If you'd like to know more about provider signing, you can read about it here:
+	https://opentofu.org/docs/cli/plugins/signing/
 
-   If you ever set or change modules or backend configuration for Terraform,
-   rerun this command to reinitialize your working directory. If you forget, other
-   commands will detect it and remind you to do so if necessary.
-   OpenStack Cloud Name: openstack
-   Password:
+	OpenTofu has made some changes to the provider dependency selections recorded
+	in the .terraform.lock.hcl file. Review those changes and commit them to your
+	version control system if they represent changes you intended to make.
+
+	╷
+	│ Warning: Dependency lock file entries automatically updated
+	│
+	│ OpenTofu automatically rewrote some entries in your dependency lock file:
+	│   - registry.terraform.io/hashicorp/local => registry.opentofu.org/hashicorp/local
+	│
+	│ The version selections were preserved, but the hashes were not because the OpenTofu project's provider releases are not byte-for-byte identical.
+	╵
+
+	OpenTofu has been successfully initialized!
+
+	You may now begin working with OpenTofu. Try running "tofu plan" to see
+	any changes that are required for your infrastructure. All OpenTofu commands
+	should now work.
+
+	If you ever set or change modules or backend configuration for OpenTofu,
+	rerun this command to reinitialize your working directory. If you forget, other
+	commands will detect it and remind you to do so if necessary.
+	OpenStack Cloud Name: openstack
+	Password:
 
 You must ensure that you have `Ansible installed <https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html>`_ on your local machine.
 
@@ -213,10 +254,10 @@ If the deployed instances are behind an SSH bastion you must ensure that your SS
       StrictHostKeyChecking no
       IdentitiesOnly yes
 
-Configure Terraform variables
+Configure OpenTofu variables
 =============================
 
-Populate Terraform variables in `terraform.tfvars`. Examples are provided in
+Populate OpenTofu variables in `terraform.tfvars`. Examples are provided in
 files named `*.tfvars.example`. The available variables are defined in
 `variables.tf` along with their type, description, and optional default.
 
@@ -264,7 +305,7 @@ control host. The session is logged to `~/tmux.kayobe\:0.log` on the Ansible
 control host. Use `less -r ~/tmux.kayobe\:0.log` to view the logs in their
 original colourful glory.
 
-Note that this approach requires all Terraform, Ansible, Kayobe and OpenStack
+Note that this approach requires all OpenTofu, Ansible, Kayobe and OpenStack
 configuration to be provided in advance. For Kayobe and OpenStack
 configuration, this may be achieved by providing suitable branches for the
 kayobe-config and openstack-config repositories and referencing them in
@@ -287,20 +328,20 @@ This section describes a more hands-on, interactive deployment method. It may
 be useful to gain a better understanding of how the deployment works, modify
 the deployment process in some way, or iterate on configuration.
 
-Terraform Deploy infrastructure using Terraform
+Deploy infrastructure using OpenTofu
 -----------------------------------------------
 
 Generate a plan:
 
 .. code-block:: console
 
-   terraform plan
+   tofu plan
 
 Apply the changes:
 
 .. code-block:: console
 
-   terraform apply -auto-approve
+   tofu apply -auto-approve
 
 You should have requested a number of resources to be spawned on Openstack.
 
@@ -336,7 +377,7 @@ If you choose to opt for the automated method you must first SSH into your Ansib
 
 .. code-block:: console
 
-   ssh $(terraform output -raw ssh_user)@$(terraform output -raw ansible_control_access_ip_v4)
+   ssh $(tofu output -raw ssh_user)@$(tofu output -raw ansible_control_access_ip_v4)
 
 Start a `tmux` session to avoid halting the deployment if you are disconnected.
 
@@ -358,14 +399,14 @@ Using software such as sshuttle will allow for easy access.
 
 .. code-block:: console
 
-   sshuttle -r $(terraform output -raw ssh_user)@$(terraform output -raw seed_access_ip_v4) 192.168.39.0/24
+   sshuttle -r $(tofu output -raw ssh_user)@$(tofu output -raw seed_access_ip_v4) 192.168.39.0/24
 
 You may also use sshuttle to proxy DNS via the multinode environment. Useful if you are working with Designate.
 Important to note this will proxy all DNS requests from your machine to the first controller within the multinode environment.
 
 .. code-block:: console
 
-   sshuttle -r $(terraform output -raw ssh_user)@$(terraform output -raw seed_access_ip_v4) 192.168.39.0/24 --dns --to-ns 192.168.39.4
+   sshuttle -r $(tofu output -raw ssh_user)@$(tofu output -raw seed_access_ip_v4) 192.168.39.0/24 --dns --to-ns 192.168.39.4
 
 Tear Down
 =========
@@ -378,17 +419,17 @@ If you would like to delete your Ansible control host then you can pass the `-a`
 Issues & Fixes
 ==============
 
-Sometimes a compute instance fails to be provisioned by Terraform or fails on boot for any reason.
-If this happens the solution is to mark the resource as tainted and perform terraform apply again which shall destroy and rebuild the failed instance.
+Sometimes a compute instance fails to be provisioned by OpenTofu or fails on boot for any reason.
+If this happens the solution is to mark the resource as tainted and perform ``tofu apply`` again which shall destroy and rebuild the failed instance.
 
 .. code-block:: console
 
-   terraform taint 'openstack_compute_instance_v2.controller[2]'
-   terraform apply
+   tofu taint 'openstack_compute_instance_v2.controller[2]'
+   tofu apply
 
 Also sometimes the provider may fail to notice that some resources are functioning as expected due to timeouts or other network issues.
-If you can confirm via Horizon or via SSH that the resource is functioning as expected you may untaint the resource preventing Terraform from destroying on subsequent terraform apply.
+If you can confirm via Horizon or via SSH that the resource is functioning as expected you may untaint the resource preventing OpenTofu from destroying on subsequent ``tofu apply``.
 
 .. code-block:: console
 
-   terraform untaint 'openstack_compute_instance_v2.controller[2]'
+   tofu untaint 'openstack_compute_instance_v2.controller[2]'

--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -1,1 +1,2 @@
 plugin: cloud.terraform.terraform_provider
+binary_path: /usr/bin/tofu

--- a/init.sh
+++ b/init.sh
@@ -1,4 +1,5 @@
-terraform -chdir=$(dirname $0) init
+mydir=$(cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
+tofu -chdir="$mydir" init
 echo -n "OpenStack Cloud Name: "
 read OS_CLOUD
 export OS_CLOUD

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -6,8 +6,8 @@ set -eux
 set -o pipefail
 
 # Check for dependencies
-if ! type terraform; then
-  echo "Unable to find Terraform"
+if ! type tofu; then
+  echo "Unable to find OpenTofu"
   exit 1
 fi
 if ! type ansible; then
@@ -15,9 +15,9 @@ if ! type ansible; then
   exit 1
 fi
 
-# Deploy infrastructure using Terraform.
-terraform plan
-terraform apply -auto-approve
+# Deploy infrastructure using OpenTofu.
+tofu plan
+tofu apply -auto-approve
 
 # Configure the Ansible control host.
 ansible-playbook -i ansible/inventory.yml ansible/configure-hosts.yml

--- a/scripts/tear-down.sh
+++ b/scripts/tear-down.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-# This script is capable of destroying your multinode environment via Terraform in targeted manner.
-# As Terraform lacks a skip flag when destroying resources it means that you can only delete
+# This script is capable of destroying your multinode environment via OpenTofu in targeted manner.
+# As OpenTofu lacks a skip flag when destroying resources it means that you can only delete
 # everything or resources explicitly mentioned with the target flag.
 #
 # This is less than ideal within the multinode environment as we will want to keep intact the Ansible Control Host and keypair.
@@ -28,7 +28,7 @@ done
 
 if [ $ALL == true ]; then
     if [ $KEY == false ]; then
-      terraform destroy \
+      tofu destroy \
         -target=openstack_compute_instance_v2.ansible_control \
         -target=openstack_compute_instance_v2.controller \
         -target=openstack_compute_instance_v2.compute \
@@ -37,10 +37,10 @@ if [ $ALL == true ]; then
         -target=openstack_blockstorage_volume_v3.volumes \
         -target=openstack_compute_volume_attach_v2.attachments
     else
-      terraform destroy
+      tofu destroy
     fi
 else
-  terraform destroy -target=openstack_compute_instance_v2.controller \
+  tofu destroy -target=openstack_compute_instance_v2.controller \
     -target=openstack_compute_instance_v2.compute \
     -target=openstack_compute_instance_v2.seed \
     -target=openstack_compute_instance_v2.storage \


### PR DESCRIPTION
See #102

The part we really want is `binary_path: /usr/bin/tofu` in `ansible/inventory.yml`, rest is documentation/handy shell script.