### PR TITLE
Update README.rst to reflect new internal ips

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -246,7 +246,7 @@ If the deployed instances are behind an SSH bastion you must ensure that your SS
       User username
       IdentityFile ~/.ssh/key
 
-   Host 10.*
+   Host 172.16.*
       ProxyJump=lab-bastion
       ForwardAgent no
       IdentityFile ~/.ssh/key


### PR DESCRIPTION
Old ssh config step does not work with new ip convention 172.16.*, updated accordingly