### PR TITLE
Bump openstack provider version

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     openstack = {
       source  = "terraform-provider-openstack/openstack"
-      version = "1.49.0"
+      version = "3.4.0"
     }
     ansible = {
       source = "ansible/ansible"


### PR DESCRIPTION
Existing version used isn't compatible with 2026.1, bumping up to 3.4.0 fixes this.